### PR TITLE
Check title

### DIFF
--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -341,9 +341,10 @@ func (mgr *Manager) vmLoop() {
 				reproInstances += instancesPerRepro
 				atomic.AddUint32(&mgr.numReproducing, 1)
 				log.Logf(1, "loop: starting repro of '%v' on instances %+v", crash.Title, vmIndexes)
+
 				go func() {
 					features := mgr.checkResult.Features
-					res, stats, err := repro.Run(crash.Output, mgr.cfg, features, mgr.reporter, mgr.vmPool, vmIndexes)
+					res, stats, err := repro.Run(crash.Output, mgr.cfg, features, mgr.reporter, mgr.vmPool, vmIndexes, nil)
 					reproDone <- &ReproResult{
 						instances: vmIndexes,
 						report0:   crash.Report,


### PR DESCRIPTION
Add functionality so that if newly added `title` flag is set to true, when a crash is reproduced, the user is prompted to read the crash title and choose if it should be reproduced or not.