### PR TITLE
pkg/repro: extractProgStrategy

### DIFF
--- a/pkg/repro/repro.go
+++ b/pkg/repro/repro.go
@@ -300,6 +300,10 @@ func (ctx *context) extractProg(entries []*prog.LogEntry) (*Result, error) {
 		ctx.stats.ExtractProgTime = time.Since(start)
 	}()
 
+	return ctx.extractProgStrategy(entries)
+}
+
+func (ctx *context) extractProgStrategy(entries []*prog.LogEntry) (*Result, error) {
 	// Extract last program on every proc.
 	procs := make(map[int]int)
 	for i, ent := range entries {


### PR DESCRIPTION
Refactor code in extractProg into separate function extractProgStrategy
to allow for implementation of different strategies (functions) of
extracting programs.
