### PR TITLE
syz-manager: add hub flag

### DIFF
--- a/syz-manager/hub.go
+++ b/syz-manager/hub.go
@@ -57,7 +57,11 @@ type HubManagerView interface {
 
 func (hc *HubConnector) loop() {
 	var hub *rpctype.RPCClient
-	for ; ; time.Sleep(10 * time.Minute) {
+	timeout := 10 * time.Minute
+	if *flagHub {
+		timeout = 3 * time.Minute
+	}
+	for ; ; time.Sleep(timeout) {
 		corpus, repros := hc.mgr.getMinimizedCorpus()
 		hc.newRepros = append(hc.newRepros, repros...)
 		if hub == nil {

--- a/syz-manager/manager.go
+++ b/syz-manager/manager.go
@@ -42,6 +42,7 @@ var (
 	flagConfig = flag.String("config", "", "configuration file")
 	flagDebug  = flag.Bool("debug", false, "dump all VM output to console")
 	flagBench  = flag.String("bench", "", "write execution statistics into this file periodically")
+	flagHub    = flag.Bool("hub", false, "run syz-manager suited to interact with syz-hub")
 )
 
 type Manager struct {
@@ -447,6 +448,9 @@ func (mgr *Manager) preloadCorpus() {
 	}
 	mgr.corpusDB = corpusDB
 
+	if *flagHub {
+		return
+	}
 	if seedDir := filepath.Join(mgr.cfg.Syzkaller, "sys", mgr.cfg.TargetOS, "test"); osutil.IsExist(seedDir) {
 		seeds, err := ioutil.ReadDir(seedDir)
 		if err != nil {


### PR DESCRIPTION
Added hub flag to syz-manager that will disable the loading of mgr.seeds
from syzkaller/sys/{OS}/test and will change the hubSyncLoop sync wait
time from 10 minutes to 3 minutes.
